### PR TITLE
Image is now working without musl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,25 @@
 ####################################################################################################
 ## Builder
 ####################################################################################################
-FROM clux/muslrust:stable AS builder
+FROM rust:latest AS builder
 
+WORKDIR /app
 COPY Cargo.toml .
 COPY Cargo.lock .
 COPY benches benches
 COPY assets assets
 COPY src src
 
-RUN --mount=type=cache,target=/volume/target \
+RUN --mount=type=cache,target=/app/target \
     --mount=type=cache,target=/root/.cargo/registry \
     cargo build --release --bin rod && \
-    mv /volume/target/x86_64-unknown-linux-musl/release/rod .
+    mv /app/target/release/rod .
 
 ####################################################################################################
 ## Final image
 ####################################################################################################
-FROM gcr.io/distroless/static:nonroot
-COPY --from=builder --chown=nonroot:nonroot /volume/rod /app/
+FROM gcr.io/distroless/cc
+COPY assets /assets
+COPY --from=builder /app/rod /
 EXPOSE 4944 4945
-ENTRYPOINT ["/app/rod"]
+ENTRYPOINT ["./rod"]


### PR DESCRIPTION
I was unable to run the image correctly after building with musl, it seems like the binary is running inside the container but the web server does not respond. 

This PR is building an image that actually works.

** Test Plan **
```
docker run -p 4944:4944 -p 4945:4945 rod start
Rod node starting...
Iris UI:            http://localhost:4945
Stats:              http://localhost:4945/stats
Websocket endpoint: ws://0.0.0.0:4944/ws
```

