### PR TITLE
fix: eliminate TOCTOU race and potential panic in Node::get

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -219,8 +219,8 @@ impl Node {
             return self.clone();
         }
         debug!("get key {}", key);
-        if self.children.read().unwrap().contains_key(key) {
-            self.children.read().unwrap().get(key).unwrap().clone() // TODO: theoretically, key could have been removed?
+        if let Some(child) = self.children.read().unwrap().get(key) {
+            child.clone()
         } else {
             self.new_child(key.to_string())
         }


### PR DESCRIPTION
Replace double read-lock pattern (contains_key + get) with a single read lock using if-let, removing the window where another thread could delete the key between the two lock acquisitions and causing unwrap() to panic.